### PR TITLE
Обновил строку импорта мифик+

### DIFF
--- a/guide/brewmaster/talents.html
+++ b/guide/brewmaster/talents.html
@@ -4702,8 +4702,8 @@
 					</div>
 					<div class="format-code" align="center"><code><wb>СТРОКА ИМПОРТА (МИФИК+):</wb><br>
 						BwQAdeydY63Y4XKaboK13uRRQAAAAAAA<br>
-						QAAAAQShSJJJESSatDIAAAA<br>
-						pFkEJSIhkkkkSCIiEpliA</code></div>
+						QAAAAQShWJJJgkkWLCAAAQ<br>
+						aBJRiESIJJJpkAiIRapIA</code></div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
В канале Брюмастеров сообщили: "В гайде на сайте картинка и строка импорта билда для инстов отличаются".
Сделал строку как на картинке: 
- Убрал очко из Целебный элексир и поставил в Высокая стойкость. (на картинке не берется Эликсир)
- Заменил Упрощенный рецепт на Уроки Нюцзао. (На картинке Уроки, а по ссылке Рецепт)
- [
![image](https://user-images.githubusercontent.com/107807904/205804908-f92a896d-6e27-47e7-9750-511ee6e495a9.png)
](url)